### PR TITLE
Nonpr 2548

### DIFF
--- a/src/main/scala/uk/gov/hmrc/nonrep/attachment/server/ServiceConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/nonrep/attachment/server/ServiceConfig.scala
@@ -11,15 +11,7 @@ class ServiceConfig(val servicePort: Int = 8000) {
   val port: Int = sys.env.get("REST_PORT").fold(servicePort)(_.toInt)
   val env: String = sys.env.getOrElse("ENV", "local")
 
-  def isSandbox = !Set("dev", "qa", "staging", "production").contains(env)
-
-  val glacierNotificationsSnsTopicArn: String = if (env == "local") "local" else glacierSNSSystemProperty
-
-  private[server] def glacierSNSSystemProperty =
-    sys.env.getOrElse(
-      "GLACIER_SNS",
-      throw new IllegalStateException(
-        "System property GLACIER_SNS is not set. This is required by the service to create a Glacier vault when necessary."))
+  def isSandbox: Boolean = !Set("dev", "qa", "staging", "production").contains(env)
 
   val queueUrl: String = if (env == "local") "local" else sqsSystemProperty
 
@@ -65,7 +57,6 @@ class ServiceConfig(val servicePort: Int = 8000) {
     env: $env
     queueUrl: $queueUrl
     elasticSearchUri: $elasticSearchUri
-    glacierNotificationsSnsTopicArn: $glacierNotificationsSnsTopicArn
     attachmentsBucket: $attachmentsBucket
     configFile: ${config.toString}"""
 

--- a/src/test/scala/uk/gov/hmrc/nonrep/attachment/TestServices.scala
+++ b/src/test/scala/uk/gov/hmrc/nonrep/attachment/TestServices.scala
@@ -123,8 +123,8 @@ object TestServices {
     }
 
     val glacierService: Glacier = new GlacierService() {
-      override def eventuallyArchive(uploadArchiveRequest: UploadArchiveRequest,
-                                     asyncRequestBody: AsyncRequestBody): Future[UploadArchiveResponse] =
+      override def eventuallyUploadArchive(uploadArchiveRequest: UploadArchiveRequest,
+                                           asyncRequestBody: AsyncRequestBody): Future[UploadArchiveResponse] =
         Future successful UploadArchiveResponse.builder().archiveId(archiveId).build()
     }
 
@@ -134,7 +134,7 @@ object TestServices {
           case (_, request) => (Try(HttpResponse(OK, entity = HttpEntity(""))), request)
         }
 
-      override def createRequestsSignerParams = new RequestsSignerParams() {
+      override def createRequestsSignerParams: RequestsSignerParams = new RequestsSignerParams() {
 
         import RequestsSigner._
 
@@ -167,8 +167,8 @@ object TestServices {
         }
     }
     val glacierService: GlacierService = new GlacierService() {
-      override def eventuallyArchive(uploadArchiveRequest: UploadArchiveRequest,
-                                     asyncRequestBody: AsyncRequestBody): Future[UploadArchiveResponse] =
+      override def eventuallyUploadArchive(uploadArchiveRequest: UploadArchiveRequest,
+                                           asyncRequestBody: AsyncRequestBody): Future[UploadArchiveResponse] =
         Future failed new RuntimeException("boom!")
     }
 
@@ -194,5 +194,4 @@ object TestServices {
         }
     }
   }
-
 }

--- a/src/test/scala/uk/gov/hmrc/nonrep/attachment/server/ServiceConfigSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/nonrep/attachment/server/ServiceConfigSpec.scala
@@ -20,17 +20,5 @@ class ServiceConfigSpec extends AnyWordSpec with Matchers {
     "be able to use default service port" in {
       config.port shouldBe config.servicePort
     }
-
-    "specify the glacier notifications SNS topic Arn" in {
-      config.glacierNotificationsSnsTopicArn shouldBe "local"
-    }
-
-    "throw an error in non-local environments" when {
-      "the mandatory GLACIER_SNS system property is not defined" in {
-        intercept[Exception] {
-          config.glacierSNSSystemProperty
-        }.getMessage shouldBe "System property GLACIER_SNS is not set. This is required by the service to create a Glacier vault when necessary."
-      }
-    }
   }
 }


### PR DESCRIPTION
Change the processor to rely on the sign service to create vaults so that the code is in one place.

```
sbt test 
...
[info] Run completed in 10 seconds, 799 milliseconds.
[info] Total number of tests run: 51
[info] Suites: completed 10, aborted 0
[info] Tests: succeeded 51, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 13 s, completed 19 Apr 2022, 16:55:49

```

```
sbt it:test
...
[info] Run completed in 6 seconds, 918 milliseconds.
[info] Total number of tests run: 5
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 5, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 7 s, completed 19 Apr 2022, 16:04:49
```

acceptance test run:
```
[info] Run completed in 4 minutes, 56 seconds.
[info] Total number of tests run: 109
[info] Suites: completed 29, aborted 0
[info] Tests: succeeded 109, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 312 s (05:12), completed 19 Apr 2022, 16:52:49
```