### PR TITLE
[NONPR-4044][DC] updating logback configuration after contract changes with version uplift

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-        <remoteHost>${LOGSTASH_URL}</remoteHost>
-        <port>${LOGSTASH_PORT}</port>
+        <destination>${LOGSTASH_URL}:${LOGSTASH_PORT}</destination>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>{"appname":"attachment-processor", "env":"${ENV}"}</customFields>
         </encoder>


### PR DESCRIPTION
logback library was updated a few months ago, which had a configuration change, host and port to destination. 

